### PR TITLE
First Implementation : Demo 3

### DIFF
--- a/03 - Clustering Misorientations.ipynb
+++ b/03 - Clustering Misorientations.ipynb
@@ -1,0 +1,375 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h1> <center> Clustering Misorientation: An example with Grain Boundaries </h1></center>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib qt5\n",
+    "\n",
+    "# Important external dependencies\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.cluster import DBSCAN\n",
+    "\n",
+    "# Other external dependencies\n",
+    "#from sklearn.datasets import make_blobs\n",
+    "\n",
+    "# Local dependencies (now conda version 0.1.1)\n",
+    "from orix.quaternion.orientation import Orientation, Misorientation\n",
+    "#from orix.quaternion.rotation import Rotation\n",
+    "from orix.quaternion.symmetry import D6#,C1, D6h,Oh\n",
+    "from orix.quaternion.orientation_region import OrientationRegion\n",
+    "#from orix.vector.neo_euler import AxAngle\n",
+    "#from orix.vector import Vector3d\n",
+    "from orix import plot\n",
+    "\n",
+    "# Colorisation\n",
+    "from skimage.color import label2rgb\n",
+    "from matplotlib.colors import to_rgb, to_hex\n",
+    "#MPL_COLORS_RGB = [to_rgb('C{}'.format(i)) for i in range(10)]\n",
+    "#MPL_COLORS_HEX = [to_hex(c) for c in MPL_COLORS_RGB]\n",
+    "\n",
+    "# Animation\n",
+    "#import matplotlib.animation as animation\n",
+    "\n",
+    "# Visualisation\n",
+    "#from mpl_toolkits.mplot3d.art3d import Line3DCollection\n",
+    "#from matplotlib.patches import Circle\n",
+    "from matplotlib.lines import Line2D\n",
+    "#from matplotlib.collections import CircleCollection\n",
+    "#from scipy.spatial import ConvexHull\n",
+    "#from mpl_toolkits.mplot3d.art3d import Poly3DCollection\n",
+    "\n",
+    "#plt.rc('font', size=6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of misorientations: 860\n"
+     ]
+    }
+   ],
+   "source": [
+    "filepath = '/home/pc494/Documents/research/Orix-paper/data/Ti_orientations.ctf'\n",
+    "# Load data from CTF file\n",
+    "dat = np.loadtxt(filepath, skiprows=1)[:, :3]\n",
+    "\n",
+    "ori = Orientation.from_euler(np.radians(dat)).reshape(381, 507)[-100:, :200].set_symmetry(D6)\n",
+    "\n",
+    "fundamental_region = OrientationRegion.from_symmetry(D6, D6)\n",
+    "\n",
+    "# Compute misorientations\n",
+    "misori_base = Misorientation(~ori[:, :-1] * ori[:, 1:])\n",
+    "boundary_mask = misori_base.angle > np.radians(7)\n",
+    "misori = misori_base[boundary_mask].set_symmetry(D6, D6)\n",
+    "print('Number of misorientations:', misori.size)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "small_mask = misori.angle < np.radians(7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<center><h2> Creating a distance metric (skip to next heading to load from a file) </h2></center>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RAM smash"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "confirm = input('Are you sure? (y/n) ')\n",
+    "if confirm == 'y':\n",
+    "    mismisori = (~misori).outer(misori)\n",
+    "    mismisori_equiv = D6.outer(~misori).outer(D6).outer(D6).outer(misori).outer(D6)\n",
+    "    distance = mismisori_equiv.angle.data.min(axis=(0, 2, 3, 5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Should work"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "confirm = input('Are you sure? (y/n) ')\n",
+    "if confirm == 'y':\n",
+    "    from itertools import combinations_with_replacement as icombinations\n",
+    "    from tqdm import tqdm_notebook\n",
+    "    distance = np.empty((misori.size, misori.size))\n",
+    "\n",
+    "    for i, j in tqdm_notebook(list(icombinations(range(misori.size), 2))):\n",
+    "        m_1, m_2 = misori[i], misori[j]\n",
+    "        mismisori = D6.outer(~m_1).outer(D6).outer(D6).outer(m_2).outer(D6)\n",
+    "        d = mismisori.angle.data.min(axis=(0, 2, 3, 5))\n",
+    "        distance[i, j] = d\n",
+    "        distance[j, i] = d"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<center> <h2> ... Or, here is one we made earlier </h2> </center>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filepath_2 = '/home/pc494/Documents/research/Orix-paper/data/misori-distance((100, 200)).npy'\n",
+    "distance = np.load(filepath_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "distance = distance[~small_mask][:, ~small_mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cluster labels: [-1  0  1  2  3]\n",
+      "Number of clusters: 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute clusters\n",
+    "dbscan = DBSCAN(0.05, 10, metric='precomputed').fit(distance)\n",
+    "print('Cluster labels:', np.unique(dbscan.labels_))\n",
+    "n_clusters = len(np.unique(dbscan.labels_)) - 1\n",
+    "print('Number of clusters:', n_clusters)\n",
+    "\n",
+    "# Generate colors\n",
+    "colors = [to_rgb('C{}'.format(i)) for i in range(10)]\n",
+    "c = label2rgb(dbscan.labels_, colors=colors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "misori = misori[~small_mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster_means = Misorientation.stack([misori[dbscan.labels_ == label].mean() for label in np.unique(dbscan.labels_)[1:]]).flatten()\n",
+    "cluster_means = cluster_means.set_symmetry(D6, D6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([57.32484832, 68.81388421, 31.58939741, 60.10115054])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.degrees(cluster_means.angle.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate map\n",
+    "mapping = np.ones(misori_base.shape + (3,))\n",
+    "\n",
+    "mapping[np.where(boundary_mask)[0][~small_mask], np.where(boundary_mask)[1][~small_mask]] = c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h2><center> Plotting our results </h2></center>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7fc63d024588>"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Plot clustered misorientations\n",
+    "fig = plt.figure(figsize=(3.484252, 3.484252))\n",
+    "gridspec = plt.GridSpec(1, 1, left=0, right=1, bottom=0, top=1, hspace=0.05)\n",
+    "\n",
+    "\n",
+    "ax_misori = fig.add_subplot(gridspec[0], projection='axangle', aspect='equal', proj_type='ortho')\n",
+    "ax_misori.scatter(misori,s=4,c=c) \n",
+    "ax_misori.plot_wireframe(fundamental_region, color='black', linewidth=0.5, alpha=0.1, rcount=361, ccount=361)\n",
+    "\n",
+    "\n",
+    "ax_misori.set_axis_off()\n",
+    "ax_misori.set_xlim(0.2, 1.2)\n",
+    "ax_misori.set_ylim(-.1, .9)\n",
+    "ax_misori.set_zlim(-0, 1)\n",
+    "ax_misori.view_init(90, -60)\n",
+    "\n",
+    "\n",
+    "handles = [\n",
+    "    Line2D(\n",
+    "        [0], [0], \n",
+    "        marker='o', color='none', \n",
+    "        label=i+1, \n",
+    "        markerfacecolor=color, markersize=5\n",
+    "    ) for i, color in enumerate(colors[:n_clusters])\n",
+    "]\n",
+    "\n",
+    "ax_misori.legend(handles=handles, loc='upper left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(3.484252*2, 1.5*2))\n",
+    "gridspec = plt.GridSpec(1, 1, left=0, right=1, bottom=0, top=1, hspace=0.05)\n",
+    "\n",
+    "ax_misori = fig.add_subplot(gridspec[0], projection='axangle', proj_type='ortho', aspect='equal')\n",
+    "ax_misori.scatter(misori, c=c, s=4)\n",
+    "ax_misori.plot_wireframe(fundamental_region, color='black', linewidth=0.5, alpha=0.1, rcount=181, ccount=361)\n",
+    "\n",
+    "ax_misori.set_axis_off()\n",
+    "ax_misori.set_xlim(0.1, 1.1)\n",
+    "ax_misori.set_ylim(0.1, 1.1)\n",
+    "ax_misori.set_zlim(-0, 1)\n",
+    "ax_misori.view_init(0, -60)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And to conclude, we plot our grain boundaries in real space"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(3.484252, 2))\n",
+    "\n",
+    "gridspec = plt.GridSpec(1, 1, left=0, right=1, bottom=0, top=1, hspace=0.05)\n",
+    "ax_mapping = fig.add_subplot(gridspec[0])\n",
+    "ax_mapping.imshow(mapping)\n",
+    "\n",
+    "ax_mapping.set_xticks([])\n",
+    "ax_mapping.set_yticks([])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This demo demonstrates clustering misorientations, here from grain boundaries here. A noteworthy change from previous similar notbook is that lines of the form:

`ax_misori.scatter(misori, c=c, s=4)` previously included `edgecolour=none`

It's not clear why this was causing problems, but I removed the use of that kwarg. As in #2 data will be made publicly available at some later point.