### PR TITLE
Update CrystalMap notebook with diffpy.structure.Structure info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data/
+.ipynb_checkpoints/

--- a/04 - Manipulating data in a crystallographic map.ipynb
+++ b/04 - Manipulating data in a crystallographic map.ipynb
@@ -8,11 +8,11 @@
     "\n",
     "In this tutorial we demonstrate the use of a light-weight `CrystalMap` class to store and manipulate orientations, crystal phases and other properties associated with every spatial coordinate in a 1D or 2D space.\n",
     "\n",
-    "The `CrystalMap` class is inspired by MTEX' `EBSD` class. It is developed to interface more easily with the scientific Python stack, like accomodating the analysis of diffraction patterns from a transmission or scanning electron microscope.\n",
+    "The `CrystalMap` class is inspired by MTEX' `EBSD` class. It is developed to interface more easily with the scientific Python stack.\n",
     "\n",
-    "Orientations and other properties acquired from a super-duplex stainless steel EBSD data set with two phases, austenite and ferrite, are used as example data. The data is available here (this data or another data set will be moved to Zenodo when the PR is merged): http://folk.ntnu.no/hakonwii/files/orix-demos/\n",
+    "Orientations and other properties acquired from a super-duplex stainless steel EBSD data set with two phases, austenite and ferrite, are used as example data. The data is available here: http://folk.ntnu.no/hakonwii/files/orix-demos/\n",
     "\n",
-    "This functionaility has been checked to run in orix-0.x (x 2020). Bugs are always possible, do not trust the code blindly, and if you experience any issues please report them here: https://github.com/pyxem/orix-demos/issues. Suggestions for improvement of the functionality we cover in this tutorial are also welcome.\n",
+    "This functionaility has been checked to run in orix-0.3.0dev (June 2020). Bugs are always possible, do not trust the code blindly, and if you experience any issues please report them here: https://github.com/pyxem/orix-demos/issues. Suggestions for improvement of the functionality we cover in this tutorial are also welcome.\n",
     "\n",
     "# Contents\n",
     "\n",
@@ -34,6 +34,7 @@
    "source": [
     "%matplotlib qt5\n",
     "\n",
+    "from diffpy.structure import Atom, Lattice, Structure\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
@@ -50,9 +51,9 @@
    "source": [
     "# <a id='obtain-crystalmap'></a> 1. Import or create a CrystalMap object\n",
     "\n",
-    "A `CrystalMap` object can be obtained either by using one of the `orix` readers or by passing the necessary arrays to the `CrystalMap.__init__()` method. Two readers are provided (so far). The `load_ang()` reader should be capable of reading indexing results from .ang files produced by softwares EDAX TSL OIM Data Collection v7, NanoMegas Astar Index, and EMsoft v4 and v5 via the `EMdpmerge` program. The `load_emsoft()` reader should be capable of reading indexing results from HDF5 files produced by EMsoft v4 and v5 via the `EMEBSDDI` program.\n",
+    "A `CrystalMap` object can be obtained by using one of the `orix` readers or by passing the necessary arrays to the `CrystalMap.__init__()` method. Two readers are provided. The `load_ang()` reader can read indexing results from .ang files produced by softwares EDAX TSL OIM Data Collection v7, NanoMegas Astar Index, and EMsoft v4 and v5 via the `EMdpmerge` program. The `load_emsoft()` reader can read indexing results from HDF5 files produced by EMsoft v4 and v5 via the `EMEBSDDI` program.\n",
     "\n",
-    "Let's read data from an .ang file produced by EMsoft"
+    "Let's get a crystal map from an .ang file produced by EMsoft"
    ]
   },
   {
@@ -66,7 +67,8 @@
     "\n",
     "cm = load_ang(datadir + fname)\n",
     "\n",
-    "# The scan unit cannot be discerned from the .ang file, so we must set this ourselves\n",
+    "# The scan unit cannot be discerned from the .ang file, so we must set this\n",
+    "# ourselves\n",
     "cm.scan_unit = \"um\"\n",
     "\n",
     "# Let's print a nice, informative representation of the data\n",
@@ -77,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the name and symmetry of the phases present in the data were obtained from the .ang file header. The indexing properties returned by EMsoft in their .ang files are the pattern image quality (iq) (according to Niels Krieger Lassen's method), and the highest dot product (dp) between the experimental and best matching simulated pattern.\n",
+    "Note that the name and symmetry of the phases present in the data were obtained from the .ang file header. The indexing properties returned by EMsoft in their .ang files are the pattern image quality (iq) (according to Niels Krieger Lassen's method), and the highest normalized dot product (dp) between the experimental and best matching simulated pattern.\n",
     "\n",
     "We can obtain the same `CrystalMap` object by reading each array from the .ang files ourselves and passing this to `CrystalMap.__init__()`"
    ]
@@ -99,6 +101,20 @@
     "# Create a property dictionary\n",
     "properties = {\"iq\": iq, \"dp\": dp}\n",
     "\n",
+    "# Create unit cells of the phases\n",
+    "structures = [\n",
+    "    Structure(\n",
+    "        title=\"austenite\",\n",
+    "        atoms=[Atom(\"fe\", [0] * 3)],\n",
+    "        lattice=Lattice(0.360, 0.360, 0.360, 90, 90, 90)\n",
+    "    ),\n",
+    "    Structure(\n",
+    "        title=\"ferrite\",\n",
+    "        atoms=[Atom(\"fe\", [0] * 3)],\n",
+    "        lattice=Lattice(0.287, 0.287, 0.287, 90, 90, 90)\n",
+    "    ),\n",
+    "]\n",
+    "\n",
     "# Create a CrystalMap object\n",
     "cm2 = CrystalMap(\n",
     "    rotations=rotations,\n",
@@ -107,6 +123,7 @@
     "    y=y,\n",
     "    phase_name=[\"austenite\", \"ferrite\"],\n",
     "    symmetry=[\"432\", \"432\"],\n",
+    "    structure=structures,\n",
     "    prop=properties,\n",
     ")\n",
     "cm2.scan_unit = \"um\"\n",
@@ -198,7 +215,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The phase name, symmetry and color can be accessed for the full phase list or a single phase"
+    "The phase name, symmetry, color and structure can be accessed for the full phase list or a single phase"
    ]
   },
   {
@@ -209,7 +226,15 @@
    "source": [
     "print(cm.phases.names)\n",
     "print([symmetry.name for symmetry in cm.phases.symmetries])\n",
-    "print(cm.phases.colors)"
+    "print(cm.phases.colors)\n",
+    "print(cm.phases.structures)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the structures' representations are empty lists since no atoms have been added to them yet."
    ]
   },
   {
@@ -221,7 +246,8 @@
     "cm.phases[\"austenite\"]\n",
     "print(cm.phases[\"austenite\"].name)\n",
     "print(cm.phases[\"austenite\"].symmetry.name)\n",
-    "print(cm.phases[\"austenite\"].color)"
+    "print(cm.phases[\"austenite\"].color)\n",
+    "print(cm.phases[\"austenite\"].structure)"
    ]
   },
   {
@@ -238,6 +264,10 @@
    "outputs": [],
    "source": [
     "cm.phases[\"austenite\"].name = \"Austenite\"\n",
+    "\n",
+    "cm.phases[\"Austenite\"].structure = Structure(\n",
+    "    lattice=Lattice(0.36, 0.36, 0.36, 90, 90, 90))\n",
+    "print(cm.phases[\"Austenite\"].structure)\n",
     "\n",
     "cm.phases[\"Austenite\"].color = \"lime\"  # Yields RGB tuple (0, 1, 0)\n",
     "print(cm.phases[\"Austenite\"].color_rgb)\n",
@@ -317,6 +347,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "When adding a phase to the phase list like this, the phases' structure contains no atoms and the default lattice parameters are used"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm.phases[\"sigma\"].structure.lattice.abcABG()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So let's set this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm.phases[\"sigma\"].structure.lattice = Lattice(0.880, 0.880, 0.880, 90, 90, 90)\n",
+    "print(cm.phases[\"sigma\"].structure.lattice)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "If some data points are considered as not indexed, a \"not_indexed\" phase can be added to the phase list to keep track of these points"
    ]
   },
@@ -384,6 +447,16 @@
     "    symmetries=['m-3m', 'm3m'],  # Note that m3m = m-3m\n",
     "    colors=['lime', 'xkcd:violet'],\n",
     "    phase_ids=[0, 1],\n",
+    "    structures=[\n",
+    "        Structure(\n",
+    "            atoms=[Atom(\"al\", [0] * 3)],\n",
+    "            lattice=Lattice(0.405, 0.405, 0.405, 90, 90, 90)\n",
+    "        ),\n",
+    "        Structure(\n",
+    "            atoms=[Atom(\"cu\", [0] * 3)],\n",
+    "            lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90)\n",
+    "        )\n",
+    "    ]\n",
     ")"
    ]
   },
@@ -401,7 +474,13 @@
    "outputs": [],
    "source": [
     "al = Phase(name='al', symmetry='m-3m', color=\"C0\")\n",
-    "cu = Phase(name='cu', color=\"C1\")\n",
+    "cu = Phase(\n",
+    "    color=\"C1\",\n",
+    "    structure=Structure(\n",
+    "        title=\"cu\",\n",
+    "        lattice=Lattice(0.361, 0.361, 0.361, 90, 90, 90)\n",
+    "    )\n",
+    ")\n",
     "\n",
     "PhaseList([al, cu])"
    ]
@@ -410,6 +489,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that the Cu phase name was retrieved from the `Structure` object.\n",
+    "\n",
     "If we want a shallow copy of the phase list"
    ]
   },

--- a/04 - Manipulating data in a crystallographic map.ipynb
+++ b/04 - Manipulating data in a crystallographic map.ipynb
@@ -12,11 +12,11 @@
     "\n",
     "Orientations and other properties acquired from a super-duplex stainless steel EBSD data set with two phases, austenite and ferrite, are used as example data. The data is available here: http://folk.ntnu.no/hakonwii/files/orix-demos/\n",
     "\n",
-    "This functionaility has been checked to run in orix-0.3.0dev (June 2020). Bugs are always possible, do not trust the code blindly, and if you experience any issues please report them here: https://github.com/pyxem/orix-demos/issues. Suggestions for improvement of the functionality we cover in this tutorial are also welcome.\n",
+    "This functionaility has been checked to run in orix-0.3.0dev (July 2020). Bugs are always possible, do not trust the code blindly, and if you experience any issues please report them here: https://github.com/pyxem/orix-demos/issues. Suggestions for improvement of the functionality we cover in this tutorial are also welcome.\n",
     "\n",
     "# Contents\n",
     "\n",
-    "1. <a href='#obtain-crystalmap'> Import or create a CrystalMap object</a>\n",
+    "1. <a href='#obtain-crystalmap'> Import/create and save a CrystalMap object</a>\n",
     "2. <a href='#inspect-phases'> Inspect and manipulate phases</a>\n",
     "3. <a href='#inspect-data'> Inspect orientation data</a>\n",
     "4. <a href='#inspect-properties'> Inspect, add and delete map properties</a>\n",
@@ -38,7 +38,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "from orix.io import load_ang, load_emsoft\n",
+    "from orix.io import load, save\n",
     "from orix.quaternion.rotation import Rotation\n",
     "from orix.quaternion.orientation import Orientation\n",
     "from orix.crystal_map import CrystalMap, PhaseList, Phase\n",
@@ -49,9 +49,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <a id='obtain-crystalmap'></a> 1. Import or create a CrystalMap object\n",
+    "# <a id='obtain-crystalmap'></a> 1. Import/create and save a CrystalMap object\n",
     "\n",
-    "A `CrystalMap` object can be obtained by using one of the `orix` readers or by passing the necessary arrays to the `CrystalMap.__init__()` method. Two readers are provided. The `load_ang()` reader can read indexing results from .ang files produced by softwares EDAX TSL OIM Data Collection v7, NanoMegas Astar Index, and EMsoft v4 and v5 via the `EMdpmerge` program. The `load_emsoft()` reader can read indexing results from HDF5 files produced by EMsoft v4 and v5 via the `EMEBSDDI` program.\n",
+    "A `CrystalMap` object can be obtained either by reading an orientation data set\n",
+    "stored in a format supported by `orix` using the `load` function, or by passing\n",
+    "the necessary arrays to the `CrystalMap.__init__()` method. Two formats are\n",
+    "supported, in addition to `orix`'s own HDF5 format: Data in the ang format\n",
+    "produced by the softwares EDAX TSL OIM Data Collection v7, NanoMegas Astar\n",
+    "Index, and EMsoft v4/v5 via the `EMdpmerge` program, and data in EMsoft v4/v5\n",
+    "HDF5 files produced by the `EMEBSDDI` program.\n",
     "\n",
     "Let's get a crystal map from an .ang file produced by EMsoft"
    ]
@@ -65,11 +71,7 @@
     "datadir = '/home/hakon/phd/data/jarle_emsoft/sdss/em/'\n",
     "fname = 'sdss_ferrite_austenite.ang'\n",
     "\n",
-    "cm = load_ang(datadir + fname)\n",
-    "\n",
-    "# The scan unit cannot be discerned from the .ang file, so we must set this\n",
-    "# ourselves\n",
-    "cm.scan_unit = \"um\"\n",
+    "cm = load(datadir + fname)\n",
     "\n",
     "# Let's print a nice, informative representation of the data\n",
     "cm"
@@ -114,6 +116,11 @@
     "        lattice=Lattice(0.287, 0.287, 0.287, 90, 90, 90)\n",
     "    ),\n",
     "]\n",
+    "phase_list = PhaseList(\n",
+    "    names=[\"austenite\", \"ferrite\"],\n",
+    "    symmetries=[\"432\", \"432\"],\n",
+    "    structures=structures,\n",
+    ")\n",
     "\n",
     "# Create a CrystalMap object\n",
     "cm2 = CrystalMap(\n",
@@ -121,14 +128,41 @@
     "    phase_id=phase_id,\n",
     "    x=x,\n",
     "    y=y,\n",
-    "    phase_name=[\"austenite\", \"ferrite\"],\n",
-    "    symmetry=[\"432\", \"432\"],\n",
-    "    structure=structures,\n",
+    "    phase_list=phase_list,\n",
     "    prop=properties,\n",
     ")\n",
     "cm2.scan_unit = \"um\"\n",
     "\n",
     "cm2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The only supported format to write a `CrystalMap` object to is `orix`'s own\n",
+    "HDF5 format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save(\n",
+    "    filename=datadir + \"sdss_ferrite_austenite2.h5\",\n",
+    "    object2write=cm,\n",
+    "    overwrite=False,  # Default\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All contents in this file can be inspected using any HDF5 viewer, read back into\n",
+    "Python using the `h5py` library (which we use)"
    ]
   },
   {
@@ -446,7 +480,7 @@
     "    names=['al', 'cu'],\n",
     "    symmetries=['m-3m', 'm3m'],  # Note that m3m = m-3m\n",
     "    colors=['lime', 'xkcd:violet'],\n",
-    "    phase_ids=[0, 1],\n",
+    "    ids=[0, 1],\n",
     "    structures=[\n",
     "        Structure(\n",
     "            atoms=[Atom(\"al\", [0] * 3)],\n",


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Adds explanations of the added `structure` attribute to the `Phase` class in notebook 4 detailing use of the `CrystalMap` class, see https://github.com/pyxem/orix/pull/66 for details.

Also adds the `.ipynb_checkpoints/` directory to `.gitignore`.