### PR TITLE
Update matplotlib doc link, acknowledge J. Hjelen for SDSS ori. data

### DIFF
--- a/04 - Manipulating data in a crystallographic map.ipynb
+++ b/04 - Manipulating data in a crystallographic map.ipynb
@@ -10,9 +10,9 @@
     "\n",
     "The `CrystalMap` class is inspired by MTEX' `EBSD` class. It is developed to interface more easily with the scientific Python stack.\n",
     "\n",
-    "Orientations and other properties acquired from a super-duplex stainless steel EBSD data set with two phases, austenite and ferrite, are used as example data. The data is available here: http://folk.ntnu.no/hakonwii/files/orix-demos/\n",
+    "Orientations and other properties acquired from a super-duplex stainless steel EBSD data set with two phases, austenite and ferrite, are used as example data. The data is available here: http://folk.ntnu.no/hakonwii/files/orix-demos/, courtesy of Prof. Jarle Hjelen (Norwegian University of Science and Technology, Norway).\n",
     "\n",
-    "This functionaility has been checked to run in orix-0.3.0dev (July 2020). Bugs are always possible, do not trust the code blindly, and if you experience any issues please report them here: https://github.com/pyxem/orix-demos/issues. Suggestions for improvement of the functionality we cover in this tutorial are also welcome.\n",
+    "This functionaility has been checked to run in orix-0.3.0 (July 2020). Bugs are always possible, do not trust the code blindly, and if you experience any issues please report them here: https://github.com/pyxem/orix-demos/issues. Suggestions for improvement of the functionality we cover in this tutorial are also welcome.\n",
     "\n",
     "# Contents\n",
     "\n",
@@ -140,7 +140,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The only supported format to write a `CrystalMap` object to is `orix`'s own\n",
+    "The only supported format to write a `CrystalMap` object to is `orix`' own\n",
     "HDF5 format"
    ]
   },
@@ -161,8 +161,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All contents in this file can be inspected using any HDF5 viewer, read back into\n",
-    "Python using the `h5py` library (which we use)"
+    "Read the file contents back into a `CrystalMap` object using `orix`' `load`\n",
+    "function.\n",
+    "\n",
+    "All contents in this file can be inspected using any HDF5 viewer and read back\n",
+    "into Python using the `h5py` library (which we use). "
    ]
   },
   {
@@ -854,7 +857,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The most powerful way to select data is by recquiring a certain criteria"
+    "The most powerful way to select data is by requiring a certain criteria"
    ]
   },
   {
@@ -874,7 +877,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that when selecting a subset of the data, a shallow copy of the crystal map is obtained. This means that whatever changes made to `cm_high_dp` also change `cm`. When we want a deep copy, we use the `CrystalMap.deepcopy()` method"
+    "Note that when selecting a subset of the data, a shallow copy (view) of the crystal map is obtained. This means that whatever changes made to `cm_high_dp` also change `cm`. When we want a deep copy, we use the `CrystalMap.deepcopy()` method"
    ]
   },
   {
@@ -1079,7 +1082,7 @@
    "source": [
     "To plot only one phase, while passing custom:\n",
     "* scalebar properties (https://matplotlib.org/mpl_toolkits/axes_grid/api/anchored_artists_api.html#mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar)\n",
-    "* legend properties (https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.pyplot.legend.html)"
+    "* legend properties (https://matplotlib.org/3.3.0/api/_as_gen/matplotlib.pyplot.legend.html)"
    ]
   },
   {


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Added a note stating that the ferrite/austenite orientation data available for the CrystalMap notebook is provided by Prof. J. Hjelen. Also updated a Matplotlib doc link.

Everything returns and plots as expected.