### PR TITLE
Update CrystalMap notebook for v0.4.0

### DIFF
--- a/04 - Manipulating data in a crystallographic map.ipynb
+++ b/04 - Manipulating data in a crystallographic map.ipynb
@@ -6,29 +6,38 @@
    "source": [
     "# Introduction\n",
     "\n",
-    "In this tutorial we demonstrate the use of a light-weight `CrystalMap` class to store and manipulate orientations, crystal phases and other properties associated with every spatial coordinate in a 1D or 2D space.\n",
+    "In this tutorial we demonstrate the use of the `CrystalMap` class to store and\n",
+    "manipulate orientations, crystal phases and other properties associated with\n",
+    "every spatial coordinate in a 1D or 2D space.\n",
     "\n",
-    "The `CrystalMap` class is inspired by MTEX' `EBSD` class. It is developed to interface more easily with the scientific Python stack.\n",
+    "The `CrystalMap` class is inspired by MTEX' `EBSD` class. It is developed to\n",
+    "interface more easily with the scientific Python stack.\n",
     "\n",
-    "Orientations and other properties acquired from a super-duplex stainless steel EBSD data set with two phases, austenite and ferrite, are used as example data. The data is available here: http://folk.ntnu.no/hakonwii/files/orix-demos/, courtesy of Prof. Jarle Hjelen (Norwegian University of Science and Technology, Norway).\n",
+    "Orientations and other properties acquired from a super-duplex stainless steel\n",
+    "EBSD data set with two phases, austenite and ferrite, are used as example data.\n",
+    "The data is available here: http://folk.ntnu.no/hakonwii/files/orix-demos/,\n",
+    "courtesy of Prof. Jarle Hjelen (Norwegian University of Science and Technology,\n",
+    "Norway).\n",
     "\n",
-    "This functionaility has been checked to run in orix-0.3.0 (July 2020). Bugs are always possible, do not trust the code blindly, and if you experience any issues please report them here: https://github.com/pyxem/orix-demos/issues. Suggestions for improvement of the functionality we cover in this tutorial are also welcome.\n",
+    "This functionaility has been checked to run in orix-0.4.0 (August 2020). Bugs\n",
+    "are always possible, do not trust the code blindly, and if you experience any\n",
+    "issues please report them here: https://github.com/pyxem/orix-demos/issues.\n",
     "\n",
     "# Contents\n",
     "\n",
-    "1. <a href='#obtain-crystalmap'> Import/create and save a CrystalMap object</a>\n",
-    "2. <a href='#inspect-phases'> Inspect and manipulate phases</a>\n",
-    "3. <a href='#inspect-data'> Inspect orientation data</a>\n",
-    "4. <a href='#inspect-properties'> Inspect, add and delete map properties</a>\n",
-    "5. <a href='#select-data'> Select and manipulate data based upon criteria</a>\n",
-    "6. <a href='#plot-maps'> Plot maps</a>\n",
+    "1. <a href='#obtain-crystalmap'>Import/create and save a CrystalMap</a>\n",
+    "2. <a href='#inspect-phases'>Create and manipulate phases</a>\n",
+    "3. <a href='#inspect-data'>Inspect orientation data</a>\n",
+    "4. <a href='#inspect-properties'>Inspect, add and delete map properties</a>\n",
+    "5. <a href='#select-data'>Select and manipulate data based upon criteria</a>\n",
+    "6. <a href='#plot-maps'>Plot maps</a>\n",
     "\n",
     "Import orix classes and various dependencies"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,9 +73,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Phase  Orientations       Name  Space group  Point group  Proper point group       Color\n",
+       "    1  5657 (48.4%)  austenite         None          432                 432    tab:blue\n",
+       "    2  6043 (51.6%)    ferrite         None          432                 432  tab:orange\n",
+       "Properties: iq, dp\n",
+       "Scan unit: um"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "datadir = '/home/hakon/phd/data/jarle_emsoft/sdss/em/'\n",
     "fname = 'sdss_ferrite_austenite.ang'\n",
@@ -1281,7 +1305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/04 - Manipulating data in a crystallographic map.ipynb
+++ b/04 - Manipulating data in a crystallographic map.ipynb
@@ -47,11 +47,12 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
+    "from orix import plot\n",
     "from orix.io import load, save\n",
-    "from orix.quaternion.rotation import Rotation\n",
-    "from orix.quaternion.orientation import Orientation\n",
     "from orix.crystal_map import CrystalMap, PhaseList, Phase\n",
-    "from orix import plot"
+    "from orix.quaternion.orientation import Orientation\n",
+    "from orix.quaternion.rotation import Rotation\n",
+    "from orix.symmetry import get_point_group"
    ]
   },
   {
@@ -69,6 +70,13 @@
     "HDF5 files produced by the `EMEBSDDI` program.\n",
     "\n",
     "Let's get a crystal map from an .ang file produced by EMsoft"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1.1 Import"
    ]
   },
   {
@@ -95,6 +103,8 @@
     "EMsoft in their .ang files are the pattern image quality (iq) (according to\n",
     "Niels Krieger Lassen's method), and the highest normalized dot product (dp)\n",
     "between the experimental and best matching simulated pattern.\n",
+    "\n",
+    "## 1.2 Create\n",
     "\n",
     "The same `CrystalMap` object can be obtained by reading each array from the\n",
     ".ang file ourselves and passing this to `CrystalMap.__init__()`"
@@ -154,6 +164,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## 1.3 Save\n",
+    "\n",
     "The only supported format to write a `CrystalMap` object to is `orix`' own\n",
     "HDF5 format"
    ]
@@ -167,7 +179,7 @@
     "save(\n",
     "    filename=datadir + \"sdss_ferrite_austenite2.h5\",\n",
     "    object2write=cm,\n",
-    "    overwrite=True,  # Default\n",
+    "    overwrite=True,  # Default is False\n",
     ")"
    ]
   },
@@ -204,6 +216,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## 2.1 Space groups"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The point group symmetry are stored in the vendor and EMsoft files, however they\n",
     "provide no space group symmetry. We can set this *per phase* by providing a\n",
     "space group number (1-230) according to the International Tables of\n",
@@ -231,7 +250,89 @@
     "mirror planes, stayed the same. The `space_group` attribute stores a\n",
     "`diffpy.structure.spacegroups.SpaceGroup` object (https://www.diffpy.org/diffpy.structure/mod_spacegroup.html#diffpy.structure.spacegroupmod.SpaceGroup).\n",
     "\n",
-    "This list can be indexed by phase ID or name"
+    "We can get the point group which a space group is the subgroup of"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(get_point_group(200).name, get_point_group(230).name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The point group stores symmetry operations as quaternions. We can get them as\n",
+    "orientation matrices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm.phases[1].point_group[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm.phases[1].point_group[:2].to_matrix()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`diffpy.structure` stores rotation symmetry operations as orientation matrices\n",
+    "and translations as 1D arrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[(i.R, i.t) for i in cm.phases[1].space_group.symop_list[:2]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can get the quaternion representation of these matrices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[Rotation.from_matrix(i.R) for i in cm.phases[1].space_group.symop_list[:2]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.2 Indexing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The phase list can be indexed by phase ID or name"
    ]
   },
   {
@@ -286,6 +387,13 @@
    "outputs": [],
    "source": [
     "print(type(cm.phases[1]), type(cm.phases[1:]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.3 Access and set properties"
    ]
   },
   {
@@ -363,6 +471,8 @@
    "metadata": {},
    "source": [
     "Valid color strings can be found here: https://matplotlib.org/3.1.0/tutorials/colors/colors.html\n",
+    "\n",
+    "## 2.4 Point groups and adding/removing a phase to/from the list\n",
     "\n",
     "Valid point group names to use when setting the point group symmetry are"
    ]
@@ -521,6 +631,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## 2.5 Creating a phase list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We can create a phase list by calling `PhaseList.__init__()`"
    ]
   },
@@ -579,6 +696,8 @@
    "metadata": {},
    "source": [
     "Note that the Cu phase name was retrieved from the `Structure` object.\n",
+    "\n",
+    "## 2.6 Copying\n",
     "\n",
     "If we want a shallow copy of the phase list"
    ]
@@ -964,7 +1083,7 @@
    "source": [
     "# <a id='plot-maps'></a> 6. Plot maps\n",
     "\n",
-    "All map plotting is done via a so-called Matplotlib \"projection\" named \"plot_map\". To plot a phase map"
+    "All map plotting is done via a `matplotlib` \"projection\" named \"plot_map\". To plot a phase map"
    ]
   },
   {
@@ -984,7 +1103,7 @@
    "source": [
     "Hover over figure points to display the (x,y) position and orientations in that point!\n",
     "\n",
-    "Note that `plot_map()` wraps `matplotlib.axes.Axes.imshow`. All key word arguments in `plot_map()` are passed to `imshow()`, so be sure to check [its documentation]((https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.imshow.html?highlight=imshow#matplotlib.axes.Axes.imshow)) out for any additional arguments.\n",
+    "Note that `plot_map()` wraps `matplotlib.axes.Axes.imshow`. All key word arguments in `plot_map()` are passed to `imshow()`, so be sure to check [its documentation](https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.imshow.html?highlight=imshow#matplotlib.axes.Axes.imshow) out for any additional arguments.\n",
     "\n",
     "We can add any overlay, from any property with a value in each map point, to the map"
    ]

--- a/04 - Manipulating data in a crystallographic map.ipynb
+++ b/04 - Manipulating data in a crystallographic map.ipynb
@@ -26,7 +26,7 @@
     "# Contents\n",
     "\n",
     "1. <a href='#obtain-crystalmap'>Import/create and save a CrystalMap</a>\n",
-    "2. <a href='#inspect-phases'>Create and manipulate phases</a>\n",
+    "2. <a href='#manipulate-phases'>Create and manipulate phases</a>\n",
     "3. <a href='#inspect-data'>Inspect orientation data</a>\n",
     "4. <a href='#inspect-properties'>Inspect, add and delete map properties</a>\n",
     "5. <a href='#select-data'>Select and manipulate data based upon criteria</a>\n",
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,11 +60,11 @@
    "source": [
     "# <a id='obtain-crystalmap'></a> 1. Import/create and save a CrystalMap object\n",
     "\n",
-    "A `CrystalMap` object can be obtained either by reading an orientation data set\n",
-    "stored in a format supported by `orix` using the `load` function, or by passing\n",
-    "the necessary arrays to the `CrystalMap.__init__()` method. Two formats are\n",
+    "A `CrystalMap` object can be obtained by reading an orientation data set stored\n",
+    "in a format supported by `orix` using the `load` function, or by passing the\n",
+    "necessary arrays to the `CrystalMap.__init__()` method. Two formats are\n",
     "supported, in addition to `orix`'s own HDF5 format: Data in the ang format\n",
-    "produced by the softwares EDAX TSL OIM Data Collection v7, NanoMegas Astar\n",
+    "produced by the softwares EDAX TSL OIM Data Collection v7, NanoMegas ASTAR\n",
     "Index, and EMsoft v4/v5 via the `EMdpmerge` program, and data in EMsoft v4/v5\n",
     "HDF5 files produced by the `EMEBSDDI` program.\n",
     "\n",
@@ -73,24 +73,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Phase  Orientations       Name  Space group  Point group  Proper point group       Color\n",
-       "    1  5657 (48.4%)  austenite         None          432                 432    tab:blue\n",
-       "    2  6043 (51.6%)    ferrite         None          432                 432  tab:orange\n",
-       "Properties: iq, dp\n",
-       "Scan unit: um"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "datadir = '/home/hakon/phd/data/jarle_emsoft/sdss/em/'\n",
     "fname = 'sdss_ferrite_austenite.ang'\n",
@@ -105,9 +90,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the name and symmetry of the phases present in the data were obtained from the .ang file header. The indexing properties returned by EMsoft in their .ang files are the pattern image quality (iq) (according to Niels Krieger Lassen's method), and the highest normalized dot product (dp) between the experimental and best matching simulated pattern.\n",
+    "Note that the name and point group symmetry of the phases present in the data\n",
+    "were obtained from the .ang file header. The indexing properties returned by\n",
+    "EMsoft in their .ang files are the pattern image quality (iq) (according to\n",
+    "Niels Krieger Lassen's method), and the highest normalized dot product (dp)\n",
+    "between the experimental and best matching simulated pattern.\n",
     "\n",
-    "We can obtain the same `CrystalMap` object by reading each array from the .ang files ourselves and passing this to `CrystalMap.__init__()`"
+    "The same `CrystalMap` object can be obtained by reading each array from the\n",
+    ".ang file ourselves and passing this to `CrystalMap.__init__()`"
    ]
   },
   {
@@ -142,7 +132,7 @@
     "]\n",
     "phase_list = PhaseList(\n",
     "    names=[\"austenite\", \"ferrite\"],\n",
-    "    symmetries=[\"432\", \"432\"],\n",
+    "    point_groups=[\"432\", \"432\"],\n",
     "    structures=structures,\n",
     ")\n",
     "\n",
@@ -177,7 +167,7 @@
     "save(\n",
     "    filename=datadir + \"sdss_ferrite_austenite2.h5\",\n",
     "    object2write=cm,\n",
-    "    overwrite=False,  # Default\n",
+    "    overwrite=True,  # Default\n",
     ")"
    ]
   },
@@ -185,18 +175,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Read the file contents back into a `CrystalMap` object using `orix`' `load`\n",
+    "Read the file contents back into a `CrystalMap` object using `orix.io.load`\n",
     "function.\n",
     "\n",
     "All contents in this file can be inspected using any HDF5 viewer and read back\n",
-    "into Python using the `h5py` library (which we use). "
+    "into Python using the `h5py` library (which we use)."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <a id='inspect-phases'></a> 2. Inspect and manipulate phases\n",
+    "# <a id='manipulate-phases'></a> 2. Create and manipulate phases\n",
     "\n",
     "The phases are stored in a `PhaseList` object in the `CrystalMap.phases` attribute"
    ]
@@ -214,6 +204,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The point group symmetry are stored in the vendor and EMsoft files, however they\n",
+    "provide no space group symmetry. We can set this *per phase* by providing a\n",
+    "space group number (1-230) according to the International Tables of\n",
+    "Crystallography (useful link: http://img.chem.ucl.ac.uk/sgp/large/sgp.htm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm.phases[1].space_group = 225\n",
+    "cm.phases[2].space_group = 229\n",
+    "\n",
+    "cm.phases"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this also changed the point group, because this is always determined\n",
+    "from the space group. But the proper point group, without any inversion or\n",
+    "mirror planes, stayed the same. The `space_group` attribute stores a\n",
+    "`diffpy.structure.spacegroups.SpaceGroup` object (https://www.diffpy.org/diffpy.structure/mod_spacegroup.html#diffpy.structure.spacegroupmod.SpaceGroup).\n",
+    "\n",
     "This list can be indexed by phase ID or name"
    ]
   },
@@ -257,7 +274,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When asking for a single phase, either by an integer or a single string, a `Phase` object was returned. In the other cases, a `PhaseList` object was returned"
+    "When asking for a single phase, either by an integer or a single string, a\n",
+    "`Phase` object was returned. In the other cases, a `PhaseList` object was\n",
+    "returned"
    ]
   },
   {
@@ -266,17 +285,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\n",
-    "    type(cm.phases[1]),\n",
-    "    type(cm.phases[1:])\n",
-    ")"
+    "print(type(cm.phases[1]), type(cm.phases[1:]))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The phase name, symmetry, color and structure can be accessed for the full phase list or a single phase"
+    "The phase name, space group, point group, proper point group, color and\n",
+    "structure can be accessed for the full phase list or a single phase"
    ]
   },
   {
@@ -286,7 +303,9 @@
    "outputs": [],
    "source": [
     "print(cm.phases.names)\n",
-    "print([symmetry.name for symmetry in cm.phases.symmetries])\n",
+    "print([i.short_name for i in cm.phases.space_groups])\n",
+    "print([i.name for i in cm.phases.point_groups])\n",
+    "print([i.proper_subgroup.name for i in cm.phases.point_groups])\n",
     "print(cm.phases.colors)\n",
     "print(cm.phases.structures)"
    ]
@@ -306,7 +325,9 @@
    "source": [
     "cm.phases[\"austenite\"]\n",
     "print(cm.phases[\"austenite\"].name)\n",
-    "print(cm.phases[\"austenite\"].symmetry.name)\n",
+    "print(cm.phases[\"austenite\"].space_group.short_name)\n",
+    "print(cm.phases[\"austenite\"].point_group.name)\n",
+    "print(cm.phases[\"austenite\"].point_group.proper_subgroup.name)\n",
     "print(cm.phases[\"austenite\"].color)\n",
     "print(cm.phases[\"austenite\"].structure)"
    ]
@@ -327,10 +348,11 @@
     "cm.phases[\"austenite\"].name = \"Austenite\"\n",
     "\n",
     "cm.phases[\"Austenite\"].structure = Structure(\n",
-    "    lattice=Lattice(0.36, 0.36, 0.36, 90, 90, 90))\n",
+    "    lattice=Lattice(0.36, 0.36, 0.36, 90, 90, 90)\n",
+    ")\n",
     "print(cm.phases[\"Austenite\"].structure)\n",
     "\n",
-    "cm.phases[\"Austenite\"].color = \"lime\"  # Yields RGB tuple (0, 1, 0)\n",
+    "cm.phases[\"Austenite\"].color = \"lime\"  # Sets RGB tuple (0, 1, 0)\n",
     "print(cm.phases[\"Austenite\"].color_rgb)\n",
     "\n",
     "cm.phases"
@@ -342,7 +364,7 @@
    "source": [
     "Valid color strings can be found here: https://matplotlib.org/3.1.0/tutorials/colors/colors.html\n",
     "\n",
-    "Valid point group names to use when setting the phase symmetry are"
+    "Valid point group names to use when setting the point group symmetry are"
    ]
   },
   {
@@ -362,7 +384,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cm.phases[\"Austenite\"].symmetry = \"m-3m\"\n",
+    "cm.phases[\"Austenite\"].point_group = \"-43m\"\n",
     "\n",
     "cm.phases"
    ]
@@ -371,7 +393,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's revert to the correct point group (and the name, for convenience)"
+    "Note that the `space_group` was set to `None` since space group Fm-3m is not a\n",
+    "subgroup of -43m.\n",
+    "\n",
+    "Let's revert to the correct space group (and the name, for convenience)"
    ]
   },
   {
@@ -381,7 +406,7 @@
    "outputs": [],
    "source": [
     "cm.phases[\"Austenite\"].name = \"austenite\"\n",
-    "cm.phases[\"austenite\"].symmetry = \"432\"\n",
+    "cm.phases[\"austenite\"].space_group = 225\n",
     "\n",
     "cm.phases"
    ]
@@ -441,7 +466,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If some data points are considered as not indexed, a \"not_indexed\" phase can be added to the phase list to keep track of these points"
+    "If some data points are considered as not indexed, a \"not_indexed\" phase can be\n",
+    "added to the phase list to keep track of these points"
    ]
   },
   {
@@ -459,7 +485,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "No points in this data set are considered not indexed. A phase list with only the phases in the data, is stored in the `CrystalMap.phases_in_data` attribute"
+    "No points in this data set are considered not indexed. A phase list with only\n",
+    "the phases in the data is stored in the `phases_in_data` attribute"
    ]
   },
   {
@@ -505,7 +532,7 @@
    "source": [
     "PhaseList(\n",
     "    names=['al', 'cu'],\n",
-    "    symmetries=['m-3m', 'm3m'],  # Note that m3m = m-3m\n",
+    "    space_groups=[225, 225],\n",
     "    colors=['lime', 'xkcd:violet'],\n",
     "    ids=[0, 1],\n",
     "    structures=[\n",
@@ -525,7 +552,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "or by creating `Phase` objects and passing these to the first argument in `PhaseList.__init__()` as a list (or single `Phase` objects)"
+    "or by creating `Phase` objects and passing these to the first argument in\n",
+    "`PhaseList.__init__()` as a list (or single `Phase` objects)"
    ]
   },
   {
@@ -534,7 +562,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "al = Phase(name='al', symmetry='m-3m', color=\"C0\")\n",
+    "al = Phase(name='al', space_group=225, color=\"C0\")\n",
     "cu = Phase(\n",
     "    color=\"C1\",\n",
     "    structure=Structure(\n",
@@ -609,7 +637,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Orientations *per phase* can be obtained by applying the phase symmetry"
+    "Orientations *per phase* can be obtained by applying the phase point group\n",
+    "symmetry"
    ]
   },
   {
@@ -637,7 +666,7 @@
    "outputs": [],
    "source": [
     "Orientation(cm[\"austenite\"].rotations).set_symmetry(\n",
-    "    cm[\"austenite\"].phases[1].symmetry)"
+    "    cm[\"austenite\"].phases[1].point_group)"
    ]
   },
   {
@@ -1104,7 +1133,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To plot only one phase, while passing custom:\n",
+    "To plot only one phase, while passing custom\n",
     "* scalebar properties (https://matplotlib.org/mpl_toolkits/axes_grid/api/anchored_artists_api.html#mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar)\n",
     "* legend properties (https://matplotlib.org/3.3.0/api/_as_gen/matplotlib.pyplot.legend.html)"
    ]


### PR DESCRIPTION
Signed-off-by: Håkon Wiik Ånes <hwaanes@gmail.com>

Todo:
- [x] Update what is there to work with v0.4.dev0
- [x] Show how to add space groups to phases
- [x] Show usage of `get_point_group()` from space group number
- [x] Show what useful info the space group has (symmetry operations)
- [x] Show getting quaternions from space group symmetry operations? This might be better suited in a fifth crystal geometry notebook!