### PR TITLE
Add ang writer to xmap notebook plus binder

### DIFF
--- a/04 - Manipulating data in a crystallographic map.ipynb
+++ b/04 - Manipulating data in a crystallographic map.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "# Contents\n",
     "\n",
-    "1. <a href='#obtain-crystalmap'>Import/create and save a CrystalMap</a>\n",
+    "1. <a href='#obtain-crystalmap'>Load/create and save a CrystalMap</a>\n",
     "2. <a href='#manipulate-phases'>Create and manipulate phases</a>\n",
     "3. <a href='#inspect-data'>Inspect orientation data</a>\n",
     "4. <a href='#inspect-properties'>Inspect, add and delete map properties</a>\n",
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# <a id='obtain-crystalmap'></a> 1. Import/create and save a CrystalMap object\n",
+    "# <a id='obtain-crystalmap'></a> 1. Load/create and save a CrystalMap\n",
     "\n",
     "A `CrystalMap` object can be obtained by reading an orientation data set stored\n",
     "in a format supported by `orix` using the `load` function, or by passing the\n",
@@ -69,6 +69,10 @@
     "Index, and EMsoft v4/v5 via the `EMdpmerge` program, and data in EMsoft v4/v5\n",
     "HDF5 files produced by the `EMEBSDDI` program.\n",
     "\n",
+    "Two writers are supported, namely `orix`'s own HDF5 format, readable by `orix`\n",
+    "only, and the .ang format, readable at least by MTEX and EDAX TSL OIM Analysis\n",
+    "v7.\n",
+    "\n",
     "Let's get a crystal map from an .ang file produced by EMsoft"
    ]
   },
@@ -76,29 +80,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1.1 Import"
+    "## 1.1 Load"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Phase  Orientations       Name  Space group  Point group  Proper point group       Color\n",
-       "    1  5657 (48.4%)  austenite         None          432                 432    tab:blue\n",
-       "    2  6043 (51.6%)    ferrite         None          432                 432  tab:orange\n",
-       "Properties: iq, dp\n",
-       "Scan unit: um"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "datadir = 'data/'\n",
     "fname = 'sdss_ferrite_austenite.ang'\n",
@@ -117,8 +106,30 @@
     "were obtained from the .ang file header. The indexing properties returned by\n",
     "EMsoft in their .ang files are the pattern image quality (iq) (according to\n",
     "Niels Krieger Lassen's method), and the highest normalized dot product (dp)\n",
-    "between the experimental and best matching simulated pattern.\n",
-    "\n",
+    "between the experimental and best matching simulated pattern."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For convenience, let's rename the phases..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmap.phases[\"austenite/austenite\"].name = \"austenite\"\n",
+    "xmap.phases[\"ferrite/ferrite\"].name = \"ferrite\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1.2 Create\n",
     "\n",
     "The same `CrystalMap` object can be obtained by reading each array from the\n",
@@ -127,24 +138,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Phase  Orientations       Name  Space group  Point group  Proper point group       Color\n",
-       "    1  5657 (48.4%)  austenite         None          432                 432    tab:blue\n",
-       "    2  6043 (51.6%)    ferrite         None          432                 432  tab:orange\n",
-       "Properties: iq, dp\n",
-       "Scan unit: um"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Read each column from the file\n",
     "euler1, euler2, euler3, x, y, iq, dp, phase_id = np.loadtxt(\n",
@@ -196,13 +192,20 @@
    "source": [
     "## 1.3 Save\n",
     "\n",
-    "The only supported format to write a `CrystalMap` object to is `orix`' own\n",
-    "HDF5 format"
+    "As mentioned, the two writers implemented are `orix`'s own HDF5 format and the\n",
+    ".ang format:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.3.1 orix' HDF5 format"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,6 +231,99 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### 1.3.2 .ang format"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The .ang writer supports many use cases. Some of these are demonstrated here,\n",
+    "by re-loading the saved crystal maps.\n",
+    "\n",
+    "First, let's write the multi phase map to an .ang file, specifying that the\n",
+    "`xmap.dp` property should be written to the confidence index (CI) column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname_ang1 = \"sdss_dp_ci.ang\"\n",
+    "save(\n",
+    "    filename=datadir + fname_ang1,\n",
+    "    object2write=xmap,\n",
+    "    confidence_index_prop=\"dp\"\n",
+    ")\n",
+    "\n",
+    "xmap_reload1 = load(datadir + fname_ang1)\n",
+    "print(xmap_reload1)\n",
+    "print(xmap_reload1.prop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the `iq` and `dp` properties were written to the image quality and\n",
+    "CI columns in the .ang file. The detector signal and pattern fit columns were\n",
+    "filled with zeros. Any property can be written to these columns by passing\n",
+    "property name strings to the `pattern_fit_prop` parameters etc."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also write masked maps to the file, while e.g. adding an extra column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname_ang2 = \"sdss_ferrite_extra_prop.ang\"\n",
+    "extra_prop = \"iq_times_dp\"\n",
+    "xmap.prop[extra_prop] = xmap.iq * xmap.dp\n",
+    "save(\n",
+    "    filename=datadir + fname_ang2,\n",
+    "    object2write=xmap[\"ferrite\"],\n",
+    "    overwrite=True,\n",
+    "    extra_prop=extra_prop\n",
+    ")\n",
+    "xmap_reload3 = load(datadir + fname_ang2)\n",
+    "print(xmap_reload3)\n",
+    "print(xmap_reload3.prop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that points not in data are set to `not_indexed` when reloaded from the\n",
+    ".ang file, and that all properties in points not in the data set are set to\n",
+    "zero, except for the CI column where this pproperty in points not in the data\n",
+    "(the austenite points) are set to -1, which MTEX and EDAX TSL expects in these\n",
+    "points."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, it is worth mentioning that if a map has more than one rotation/match\n",
+    "and phase ID per point, the `index` parameter can be passed to write any \"layer\"\n",
+    "of data to file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# <a id='manipulate-phases'></a> 2. Create and manipulate phases\n",
     "\n",
     "The phases are stored in a `PhaseList` object in the `CrystalMap.phases` attribute"
@@ -235,22 +331,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  austenite         None          432                 432    tab:blue\n",
-       " 2    ferrite         None          432                 432  tab:orange"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases"
    ]
@@ -274,22 +357,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  austenite        Fm-3m         m-3m                 432    tab:blue\n",
-       " 2    ferrite        Im-3m         m-3m                 432  tab:orange"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[1].space_group = 225\n",
     "xmap.phases[2].space_group = 229\n",
@@ -311,19 +381,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "m-3 m-3m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(get_point_group(200).name, get_point_group(230).name)"
    ]
@@ -338,48 +400,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Symmetry (2,)\n",
-       "[[1.     0.     0.     0.    ]\n",
-       " [0.7071 0.     0.     0.7071]]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[1].point_group[:2]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[[ 1.,  0.,  0.],\n",
-       "        [ 0.,  1.,  0.],\n",
-       "        [ 0.,  0.,  1.]],\n",
-       "\n",
-       "       [[ 0., -1.,  0.],\n",
-       "        [ 1.,  0.,  0.],\n",
-       "        [ 0.,  0.,  1.]]])"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[1].point_group[:2].to_matrix()"
    ]
@@ -394,27 +426,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(array([[1., 0., 0.],\n",
-       "         [0., 1., 0.],\n",
-       "         [0., 0., 1.]]),\n",
-       "  array([0., 0., 0.])),\n",
-       " (array([[-1.,  0.,  0.],\n",
-       "         [ 0., -1.,  0.],\n",
-       "         [ 0.,  0.,  1.]]),\n",
-       "  array([0., 0., 0.]))]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "[(i.R, i.t) for i in xmap.phases[1].space_group.symop_list[:2]]"
    ]
@@ -428,23 +442,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[Rotation (1,)\n",
-       " [[1. 0. 0. 0.]],\n",
-       " Rotation (1,)\n",
-       " [[0. 0. 0. 1.]]]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "[Rotation.from_matrix(i.R) for i in xmap.phases[1].space_group.symop_list[:2]]"
    ]
@@ -465,84 +465,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<name: austenite. space group: Fm-3m. point group: m-3m. proper point group: 432. color: tab:blue>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[1]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<name: austenite. space group: Fm-3m. point group: m-3m. proper point group: 432. color: tab:blue>"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[\"austenite\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  austenite        Fm-3m         m-3m                 432    tab:blue\n",
-       " 2    ferrite        Im-3m         m-3m                 432  tab:orange"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[1:]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  austenite        Fm-3m         m-3m                 432    tab:blue\n",
-       " 2    ferrite        Im-3m         m-3m                 432  tab:orange"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[\"austenite\", \"ferrite\"]"
    ]
@@ -558,19 +510,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'orix.crystal_map.phase_list.Phase'> <class 'orix.crystal_map.phase_list.PhaseList'>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(type(xmap.phases[1]), type(xmap.phases[1:]))"
    ]
@@ -592,24 +536,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['austenite', 'ferrite']\n",
-      "['Fm-3m', 'Im-3m']\n",
-      "['m-3m', 'm-3m']\n",
-      "['432', '432']\n",
-      "['tab:blue', 'tab:orange']\n",
-      "[[], []]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(xmap.phases.names)\n",
     "print([i.short_name for i in xmap.phases.space_groups])\n",
@@ -628,25 +559,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "austenite\n",
-      "Fm-3m\n",
-      "m-3m\n",
-      "432\n",
-      "tab:blue\n",
-      "lattice=Lattice(a=3.595, b=3.595, c=3.595, alpha=90, beta=90, gamma=90)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[\"austenite\"]\n",
     "print(xmap.phases[\"austenite\"].name)\n",
@@ -666,33 +583,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "lattice=Lattice(a=0.36, b=0.36, c=0.36, alpha=90, beta=90, gamma=90)\n",
-      "\n",
-      "(0.0, 1.0, 0.0)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  Austenite        Fm-3m         m-3m                 432        lime\n",
-       " 2    ferrite        Im-3m         m-3m                 432  tab:orange"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[\"austenite\"].name = \"Austenite\"\n",
     "\n",
@@ -720,57 +615,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['1',\n",
-       " '-1',\n",
-       " '211',\n",
-       " '121',\n",
-       " '112',\n",
-       " 'm11',\n",
-       " '1m1',\n",
-       " '11m',\n",
-       " '2/m',\n",
-       " '222',\n",
-       " 'mm2',\n",
-       " 'mmm',\n",
-       " '4',\n",
-       " '-4',\n",
-       " '4/m',\n",
-       " '422',\n",
-       " '4mm',\n",
-       " '-42m',\n",
-       " '4/mmm',\n",
-       " '3',\n",
-       " '-3',\n",
-       " '321',\n",
-       " '312',\n",
-       " '32',\n",
-       " '3m',\n",
-       " '-3m',\n",
-       " '6',\n",
-       " '-6',\n",
-       " '6/m',\n",
-       " '622',\n",
-       " '6mm',\n",
-       " '-6m2',\n",
-       " '6/mmm',\n",
-       " '23',\n",
-       " 'm-3',\n",
-       " '432',\n",
-       " '-43m',\n",
-       " 'm-3m']"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from orix.quaternion.symmetry import _groups\n",
     "\n",
@@ -779,30 +626,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/hakon/kode/orix/orix/crystal_map/phase_list.py:198: UserWarning: Setting space group to 'None', as current space group 'Fm-3m' is derived from current point group 'm-3m'.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  Austenite         None         -43m                  23        lime\n",
-       " 2    ferrite        Im-3m         m-3m                 432  tab:orange"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
     "xmap.phases[\"Austenite\"].point_group = \"-43m\"\n",
@@ -822,22 +648,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  austenite        Fm-3m         m-3m                 432        lime\n",
-       " 2    ferrite        Im-3m         m-3m                 432  tab:orange"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[\"Austenite\"].name = \"austenite\"\n",
     "xmap.phases[\"austenite\"].space_group = 225\n",
@@ -854,23 +667,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  austenite        Fm-3m         m-3m                 432        lime\n",
-       " 2    ferrite        Im-3m         m-3m                 432  tab:orange\n",
-       " 3      sigma         None        4/mmm                 422    tab:blue"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases.add(Phase(\"sigma\", point_group=\"4/mmm\"))\n",
     "\n",
@@ -886,20 +685,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(1.0, 1.0, 1.0, 90.0, 90.0, 90.0)"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[\"sigma\"].structure.lattice.abcABG()"
    ]
@@ -913,19 +701,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Lattice(a=0.88, b=0.88, c=0.88, alpha=90, beta=90, gamma=90)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases[\"sigma\"].structure.lattice = Lattice(0.880, 0.880, 0.880, 90, 90, 90)\n",
     "print(xmap.phases[\"sigma\"].structure.lattice)"
@@ -941,24 +721,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id         Name  Space group  Point group  Proper point group       Color\n",
-       "-1  not_indexed         None         None                None           w\n",
-       " 1    austenite        Fm-3m         m-3m                 432        lime\n",
-       " 2      ferrite        Im-3m         m-3m                 432  tab:orange\n",
-       " 3        sigma         None        4/mmm                 422    tab:blue"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases.add_not_indexed()\n",
     "\n",
@@ -975,22 +740,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  austenite        Fm-3m         m-3m                 432        lime\n",
-       " 2    ferrite        Im-3m         m-3m                 432  tab:orange"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.phases_in_data"
    ]
@@ -1004,22 +756,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group       Color\n",
-       " 1  austenite        Fm-3m         m-3m                 432        lime\n",
-       " 2    ferrite        Im-3m         m-3m                 432  tab:orange"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "del xmap.phases[\"sigma\"]\n",
     "del xmap.phases[-1]\n",
@@ -1043,22 +782,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id  Name  Space group  Point group  Proper point group        Color\n",
-       " 0    al        Fm-3m         m-3m                 432         lime\n",
-       " 1    cu        Fm-3m         m-3m                 432  xkcd:violet"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "PhaseList(\n",
     "    names=['al', 'cu'],\n",
@@ -1088,22 +814,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id  Name  Space group  Point group  Proper point group       Color\n",
-       " 0    al        Fm-3m         m-3m                 432    tab:blue\n",
-       " 1    cu         None         None                None  tab:orange"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "al = Phase(name='al', space_group=225, color=\"C0\")\n",
     "cu = Phase(\n",
@@ -1130,22 +843,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Id       Name  Space group  Point group  Proper point group  Color\n",
-       " 1  austenite        Fm-3m         m-3m                 432   lime\n",
-       " 2    ferrite        Im-3m         m-3m                 432      r"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pl = xmap.phases\n",
     "pl[\"ferrite\"].color = \"red\"\n",
@@ -1162,26 +862,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Id       Name  Space group  Point group  Proper point group     Color\n",
-      " 1  austenite        Fm-3m         m-3m                 432      lime\n",
-      " 2    ferrite        Im-3m         m-3m                 432         r\n",
-      " 3        chi         None         -43m                  23  tab:blue \n",
-      "\n",
-      "Id       Name  Space group  Point group  Proper point group  Color\n",
-      " 1  austenite        Fm-3m         m-3m                 432   lime\n",
-      " 2    ferrite        Im-3m         m-3m                 432      r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pl = xmap.phases.deepcopy()\n",
     "pl.add(Phase(\"chi\", point_group=\"-43m\"))\n",
@@ -1201,27 +886,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Rotation (11700,)\n",
-       "[[ 0.9358  0.3191  0.0919 -0.1185]\n",
-       " [ 0.8686  0.3569 -0.2749 -0.2064]\n",
-       " [ 0.8681  0.3581 -0.2744 -0.2068]\n",
-       " ...\n",
-       " [ 0.9126 -0.3022 -0.1552  0.2275]\n",
-       " [ 0.8854  0.3337 -0.2385  0.2187]\n",
-       " [ 0.885   0.3341 -0.2391  0.2193]]"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.rotations"
    ]
@@ -1236,27 +903,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Orientation (5657,) 1, m-3m\n",
-       "[[ 0.8686  0.3569 -0.2749 -0.2064]\n",
-       " [ 0.8681  0.3581 -0.2744 -0.2068]\n",
-       " [ 0.8684  0.3578 -0.2751 -0.2052]\n",
-       " ...\n",
-       " [ 0.9639  0.022   0.0754 -0.2545]\n",
-       " [ 0.8854  0.3337 -0.2385  0.2187]\n",
-       " [ 0.885   0.3341 -0.2391  0.2193]]"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "o_austenite = xmap[\"austenite\"].orientations\n",
     "\n",
@@ -1272,27 +921,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Orientation (5657,) 1, m-3m\n",
-       "[[ 0.8686  0.3569 -0.2749 -0.2064]\n",
-       " [ 0.8681  0.3581 -0.2744 -0.2068]\n",
-       " [ 0.8684  0.3578 -0.2751 -0.2052]\n",
-       " ...\n",
-       " [ 0.9639  0.022   0.0754 -0.2545]\n",
-       " [ 0.8854  0.3337 -0.2385  0.2187]\n",
-       " [ 0.885   0.3341 -0.2391  0.2193]]"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Orientation(xmap[\"austenite\"].rotations).set_symmetry(\n",
     "    xmap[\"austenite\"].phases[1].point_group\n",
@@ -1308,42 +939,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Scalar (5657,)\n",
-       "[1.037  1.0387 1.0375 ... 0.5391 0.9669 0.9688]"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "o_austenite.angle"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([1.03696736, 1.0386825 , 1.03750937, ..., 0.53910283, 0.96693885,\n",
-       "       0.96880627])"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Obtain as a numpy.ndarray\n",
     "o_austenite.angle.data"
@@ -1351,26 +958,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[ 0.72019044, -0.55478906, -0.41657512],\n",
-       "       [ 0.72152581, -0.55293758, -0.41672598],\n",
-       "       [ 0.72168011, -0.5548909 , -0.41385252],\n",
-       "       ...,\n",
-       "       [ 0.08257164,  0.2830162 , -0.95555416],\n",
-       "       [ 0.71787865, -0.51314515,  0.47045967],\n",
-       "       [ 0.71736549, -0.51352659,  0.47082608]])"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "o_austenite.axis.data"
    ]
@@ -1386,21 +976,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'iq': array([24.4, 24. , 30.3, ..., 25.3, 25.8, 31.7]),\n",
-       " 'dp': array([0.799, 0.797, 0.825, ..., 0.817, 0.809, 0.828])}"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.prop"
    ]
@@ -1414,40 +992,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([24.4, 24. , 30.3, ..., 25.3, 25.8, 31.7])"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.iq"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0.799, 0.797, 0.825, ..., 0.817, 0.809, 0.828])"
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.dp"
    ]
@@ -1461,20 +1017,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0, 0, 0, ..., 0, 0, 0])"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.prop[\"grain_boundary\"] = 0\n",
     "\n",
@@ -1483,20 +1028,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([    0,     1,     2, ..., 11697, 11698, 11699])"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.prop[\"grain_boundary2\"] = np.arange(xmap.size, dtype=int)\n",
     "\n",
@@ -1512,22 +1046,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'iq': array([24.4, 24. , 30.3, ..., 25.3, 25.8, 31.7]),\n",
-       " 'dp': array([0.799, 0.797, 0.825, ..., 0.817, 0.809, 0.828]),\n",
-       " 'grain_boundary': array([0, 0, 0, ..., 0, 0, 0])}"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "del xmap.prop[\"grain_boundary2\"]\n",
     "\n",
@@ -1550,23 +1071,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Phase  Orientations       Name  Space group  Point group  Proper point group  Color\n",
-       "    1  5657 (100.0%)  austenite        Fm-3m         m-3m                 432   lime\n",
-       "Properties: iq, dp, grain_boundary\n",
-       "Scan unit: um"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap[\"austenite\"]"
    ]
@@ -1580,24 +1087,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Phase  Orientations       Name  Space group  Point group  Proper point group  Color\n",
-       "    1  5657 (48.4%)  austenite        Fm-3m         m-3m                 432   lime\n",
-       "    2  6043 (51.6%)    ferrite        Im-3m         m-3m                 432      r\n",
-       "Properties: iq, dp, grain_boundary\n",
-       "Scan unit: um"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap[\"austenite\", \"ferrite\"]"
    ]
@@ -1611,24 +1103,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Phase  Orientations       Name  Space group  Point group  Proper point group  Color\n",
-       "    1  5657 (48.4%)  austenite        Fm-3m         m-3m                 432   lime\n",
-       "    2  6043 (51.6%)    ferrite        Im-3m         m-3m                 432      r\n",
-       "Properties: iq, dp, grain_boundary\n",
-       "Scan unit: um"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap[\"indexed\"]"
    ]
@@ -1642,20 +1119,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "No data."
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap[\"not_indexed\"]"
    ]
@@ -1669,40 +1135,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "11700"
-      ]
-     },
-     "execution_count": 49,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.size"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(100, 117)"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap.shape"
    ]
@@ -1716,24 +1160,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Phase  Orientations       Name  Space group  Point group  Proper point group  Color\n",
-       "    1   835 (55.7%)  austenite        Fm-3m         m-3m                 432   lime\n",
-       "    2   665 (44.3%)    ferrite        Im-3m         m-3m                 432      r\n",
-       "Properties: iq, dp, grain_boundary\n",
-       "Scan unit: um"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap[20:50, 40:90]"
    ]
@@ -1747,20 +1176,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.818987435897436\n",
-      "0.819\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dp_mean = xmap.dp.mean()\n",
     "print(dp_mean)\n",
@@ -1781,7 +1201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1797,23 +1217,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Phase  Orientations       Name  Space group  Point group  Proper point group  Color\n",
-       "    1  4092 (100.0%)  austenite        Fm-3m         m-3m                 432   lime\n",
-       "Properties: iq, dp, grain_boundary\n",
-       "Scan unit: um"
-      ]
-     },
-     "execution_count": 54,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "xmap[(xmap.dp > 0.81) & (xmap.phase_id == 1)]"
    ]
@@ -1829,12 +1235,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(projection=\"plot_map\")\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
     "im = ax.plot_map(xmap)"
    ]
   },
@@ -1851,7 +1256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1867,7 +1272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1888,7 +1293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1907,12 +1312,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(projection=\"plot_map\")\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
     "im = ax.plot_map(xmap, xmap.dp, cmap=\"inferno\")"
    ]
   },
@@ -1925,7 +1329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1941,7 +1345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1957,7 +1361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1973,15 +1377,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Get rotation angles in degrees\n",
     "angles = xmap.rotations.angle.data * 180 / np.pi\n",
     "\n",
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(projection=\"plot_map\")\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
     "im = ax.plot_map(xmap, angles, vmax=angles.max() - 10)\n",
     "\n",
     "ax.add_overlay(xmap, xmap.iq)\n",
@@ -2000,12 +1403,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(projection=\"plot_map\")\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
     "im = ax.plot_map(\n",
     "    xmap[\"austenite\"],\n",
     "    scalebar=True,  # False for removed\n",
@@ -2033,14 +1435,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "xmap2 = xmap[20:50, 40:90]\n",
     "\n",
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(projection=\"plot_map\")\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
     "ax.plot_map(xmap2)\n",
     "ax.add_overlay(xmap2, xmap2.dp)"
    ]
@@ -2054,23 +1455,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Conditional slicing\n",
     "xmap2 = xmap[xmap.dp > 0.81]\n",
     "\n",
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(projection=\"plot_map\")\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
     "ax.plot_map(xmap2, xmap2.iq, cmap=\"gray\")\n",
     "ax.add_colorbar(\"Image quality\")\n",
     "\n",
     "# Chained conditional slicing\n",
     "xmap2 = xmap[(xmap.dp > 0.81) & (xmap.phase_id == 1)]\n",
     "\n",
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(projection=\"plot_map\")\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
     "ax.plot_map(xmap2, xmap2.dp, cmap=\"cividis\")\n",
     "ax.add_colorbar(\"Dot product\");"
    ]
@@ -2084,7 +1483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2092,8 +1491,7 @@
     "this_prop = 'dp'\n",
     "\n",
     "# Plot phase map again to see color changes\n",
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(projection=\"plot_map\")\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
     "ax.plot_map(xmap)\n",
     "\n",
     "# Add overlay, passing str (can also pass numpy.ndarray)\n",
@@ -2141,7 +1539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2150,7 +1548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2159,12 +1557,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(projection=\"plot_map\")\n",
+    "fig, ax = plt.subplots(subplot_kw=dict(projection=\"plot_map\"))\n",
     "im = ax.plot_map(xmap, xmap.grain_boundary, cmap=\"gray\")"
    ]
   },
@@ -2177,17 +1574,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "\n",
     "\n",
-    "for file in [\n",
-    "    \"phase_map.png\", \"phase_no_fluff.png\", \"sdss_ferrite_austenite2.h5\"\n",
-    "]:\n",
-    "    os.remove(datadir + file)"
+    "files_to_remove = [\n",
+    "    \"phase_map.png\",\n",
+    "    \"phase_no_fluff.png\",\n",
+    "    \"sdss_ferrite_austenite2.h5\",\n",
+    "    fname_ang1,\n",
+    "    fname_ang2,\n",
+    "]\n",
+    "for file in files_to_remove:\n",
+    "    try:\n",
+    "        os.remove(datadir + file)\n",
+    "    except FileNotFoundError:\n",
+    "        pass\n",
+    "\n",
+    "#plt.close(\"all\")"
    ]
   }
  ],

--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,17 @@
-.. Zenodo
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3571031.svg?=sanitize=true
-    :target: https://doi.org/10.5281/zenodo.3571031
-    :alt: DOI
+.. Launch binder
+.. image:: https://mybinder.org/badge_logo.svg
+    :target: https://mybinder.org/v2/gh/pyxem/orix-demos/HEAD
+    :alt: Launch binder
 
 .. nbviewer
 .. image:: https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg?sanitize=true
     :target: https://nbviewer.ipython.org/github/pyxem/orix-demos/tree/master
     :alt: nbviewer
 
-.. Travis CI
-.. image:: https://travis-ci.com/pyxem/orix-demos.svg?branch=master
-    :target: https://travis-ci.com/pyxem/orix-demos
-    :alt: Build status
+.. Zenodo
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3571031.svg?=sanitize=true
+    :target: https://doi.org/10.5281/zenodo.3571031
+    :alt: DOI
 
 orix is an open-source python library for the analysis of crystal orientations and misorientations.
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,3 @@
-.. Launch binder
-.. image:: https://mybinder.org/badge_logo.svg
-    :target: https://mybinder.org/v2/gh/pyxem/orix-demos/HEAD
-    :alt: Launch binder
-
 .. nbviewer
 .. image:: https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg?sanitize=true
     :target: https://nbviewer.ipython.org/github/pyxem/orix-demos/tree/master


### PR DESCRIPTION
#### Description of the change
* Update CrystalMap notebook with .ang file writer examples, plus minor simplifications of matplotlib plotting
* Remove Travis CI badge (must test nbval in GitHub Actions)

Didn't add Binder badge to readme because we have to figure out how dependencies (orix) should be installed... Should discuss in separate issue.

#### For reviewers
<!-- Don't remove the checklist below. -->
- [x] Check that the notebook number is added to the `test_notebooks.sh` if the notebook is to be tested with `nbval`.
If so, the notebook cell outputs must be stored in the `.ipynb` file.